### PR TITLE
Create new firebase preview channel on PRs only

### DIFF
--- a/.github/workflows/firebase-hosting-preview-channel.yml
+++ b/.github/workflows/firebase-hosting-preview-channel.yml
@@ -1,5 +1,5 @@
 name: Deploy commit to new Firebase Hosting preview channel
-'on': push
+'on': pull_request
 jobs:
   build_and_deploy_to_preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We keep hitting the maximum number of channels (50), which are mostly commits that don't need to be deployed